### PR TITLE
Converted np.float to np.float64

### DIFF
--- a/fashionpedia/fp_eval.py
+++ b/fashionpedia/fp_eval.py
@@ -438,8 +438,8 @@ class FPEval(COCOeval):
                         "dtMatches": dtMatches,
                     }
 
-                    tpSum = np.cumsum(tps, axis=2).astype(dtype=np.float)
-                    fpSum = np.cumsum(fps, axis=2).astype(dtype=np.float)
+                    tpSum = np.cumsum(tps, axis=2).astype(dtype=np.float64)
+                    fpSum = np.cumsum(fps, axis=2).astype(dtype=np.float64)
 
                     for iouThrIdx in range(numIous):
                         for f1Idx in range(numF1s):


### PR DESCRIPTION
`np.float` is a deprecated type in numpy that yields the following error:

```
DeprecationWarning: np.float is a deprecated alias for the builtin float. To silence this warning, use float by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use np.float64 here.
```

I changed it to `np.float64` and the evaluation script started working again. Thank you so much for putting this repository together!